### PR TITLE
fix: nanoidを脆弱性修正版に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1160,9 +1160,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2227,9 +2227,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Dependabotアラート#168（GHSA-2v37-7h3g-55p8、nanoidのsize:0指定時の無限ループ）に対応
- 間接依存の`nanoid`（vue → postcss経由）を`3.3.16`→`3.3.18`に更新（`npm audit fix`、`--force`なし）
- 併せて`ajv`（6.12.6→6.15.0）、`brace-expansion`（1.1.16→1.1.18）も同時に更新（それぞれ別のDependabotアラートに対応する可能性あり）
- `package.json`は無変更。`vue`/`postcss`のバージョンダウングレードも発生していません（Dependabot側が指摘していた「vueを3.2.12へダウングレードする経路」は採用していません）
- ロックファイルの該当エントリのみ変更

## Test plan
- [x] `npm audit` で `found 0 vulnerabilities` を確認
- [x] `git diff package.json` が空であることを確認（依存バージョン要求に変更なし）
- [x] ロックファイル差分にvue/postcssのダウングレードが含まれないことを確認

## 補足
- PR作成時点では`npm run build`/`npm run lint`が本PRと無関係に`master`で失敗する状態でしたが、その原因（`reset.css`内の無効なIEハック構文によるlightningcssエラー）は別PR #69 で修正済みです

https://github.com/AtoraYamada/portfolio1/security/dependabot/168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiAbJhAaGQUkbc7HfRsHJH